### PR TITLE
Min version decorator

### DIFF
--- a/lhub/common/decorators.py
+++ b/lhub/common/decorators.py
@@ -1,0 +1,20 @@
+import functools
+
+from lhub.exceptions.validation import VersionMinimumNotMet
+
+
+def minimum_version(min: float, feature_label: str):
+    def min_version_decorator(func):
+        functools.wraps(func)
+
+        def minimum_version_wrapper(*args, **kwargs):
+            version = float(args[0].version.lstrip("m"))
+            if min > version:
+                raise VersionMinimumNotMet(
+                    min_version=f"m{min}",
+                    feature_label=feature_label
+                )
+            return func(*args, **kwargs)
+
+        return minimum_version_wrapper
+    return min_version_decorator


### PR DESCRIPTION
Simple decorator for use on methods of the `LogicHubAPI` class (or any class with a `version` attribute in the form of `m<version>`.

Usage examples:
```python
@minimum_version(min=10.0, feature_label="some_api_feature")
def some_api_call(self):
    [ ... ]

# Can also be used on `@property` functions, but will need to be _after_ the `@property` decorator.
@property
@minimum_version(min=10.0, feature_label="some_api_feature")
def my_property(self):
   [ ... ]
```